### PR TITLE
选择性合并(warn)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "org.virgil"
-version = "3.0.0-SNAPSHOT"
+version = "3.1.0"
 
 // please check https://docs.papermc.io/paper/dev/plugin-yml/ and https://docs.papermc.io/paper/dev/getting-started/paper-plugins/
 val pluginJson = leavesPluginJson {


### PR DESCRIPTION
修复了一直以来的方块状态问题
但是这个类本来貌似就和leaves的一些优化冲突撞上了
但是又为了保留功能 只好头疼砍头了
复用线程减少开销取消掉
换成用新的线程池来执行
只检查名称而不查状态
同时 硬编码还导致了某些配置项只能重启生效而不能通过/aki-reload
用更多的性能开销换来了和其他插件的一些兼容性和稳定性

我认为应该选择性合并：（（
